### PR TITLE
Require the right type of authorizer

### DIFF
--- a/packages/sst/src/constructs/ApiGatewayV1Api.ts
+++ b/packages/sst/src/constructs/ApiGatewayV1Api.ts
@@ -431,7 +431,7 @@ export interface ApiGatewayV1ApiLambdaRequestAuthorizer
     /**
      * This allows you to override the default settings this construct uses internally to create the authorizer.
      */
-    authorizer?: apig.TokenAuthorizer;
+    authorizer?: apig.RequestAuthorizer;
   };
 }
 


### PR DESCRIPTION
`ApiGatewayV1ApiLambdaRequestAuthorizer` should use a `RequestAuthorizer`, not `TokenAuthorizer`