### PR TITLE
Support SvelteKit 3 in svelte-kit-sst

### DIFF
--- a/.changeset/sveltekit-3-compat.md
+++ b/.changeset/sveltekit-3-compat.md
@@ -1,0 +1,5 @@
+---
+"svelte-kit-sst": patch
+---
+
+Support SvelteKit 3. `@sveltejs/kit/node/polyfills` was removed from SvelteKit 3's export map, so importing it made the Lambda handler fail to start with `ERR_PACKAGE_PATH_NOT_EXPORTED`. The call was already a no-op on Node 20+, where `crypto` and `File` are globals, so it is safe to drop for SvelteKit 1 and 2 as well. Type-only imports also move from `@sveltejs/kit/types` to `@sveltejs/kit`, which resolves on every supported major.

--- a/packages/svelte-kit-sst/src/handler/index.ts
+++ b/packages/svelte-kit-sst/src/handler/index.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { installPolyfills } from "@sveltejs/kit/node/polyfills";
-import type { Server as ServerType } from "@sveltejs/kit/types";
+import type { Server as ServerType } from "@sveltejs/kit";
 // @ts-ignore
 import { Server } from "../index.js";
 // @ts-ignore
@@ -16,8 +15,6 @@ import type {
 import { InternalEvent, convertFrom, convertTo } from "./event-mapper.js";
 import { debug } from "./logger.js";
 import { isBinaryContentType } from "./binary.js";
-
-installPolyfills();
 
 const app: ServerType = new Server(manifest);
 await app.init({ env: process.env as Record<string, string> });

--- a/packages/svelte-kit-sst/src/index.ts
+++ b/packages/svelte-kit-sst/src/index.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Builder } from "@sveltejs/kit/types";
+import type { Builder } from "@sveltejs/kit";
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 export default function () {


### PR DESCRIPTION
## Problem

`svelte-kit-sst` cannot serve a SvelteKit 3 app. The generated Lambda handler fails at import time:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './node/polyfills' is not defined
by "exports" in .../@sveltejs/kit/package.json imported from
.svelte-kit/svelte-kit-sst/server/lambda-handler/index.js
```

SvelteKit 3 removed `./node/polyfills` from its export map. SvelteKit 2 had it; 3 does not.

The [SvelteKit 3 release candidate](https://svelte.dev/blog/sveltekit-3-release-candidate) was announced on 13 August 2026, and `@sveltejs/adapter-auto@8.0.0-next.3` still routes `process.env.SST` to `svelte-kit-sst` version `2`, so this adapter is on the SvelteKit 3 path today.

## Change

1. **Drop `installPolyfills()` and its import.** This is the fix.
2. **Move the two type-only imports from `@sveltejs/kit/types` to `@sveltejs/kit`.** Bonus!

## Why this is safe on SvelteKit 1 and 2 as well

**The polyfill call was already doing nothing.** SvelteKit 2's `installPolyfills` only ever installed `crypto` and `File`, and it skips any name already present on `globalThis`:

```js
const globals = { crypto, File };
export function installPolyfills() {
  for (const name in globals) {
    if (name in globalThis) continue;
    ...
  }
}
```

Both are globals from Node 20. `sst.aws.SvelteKit` defaults its server function to `nodejs24.x`, and this repo recently moved the default runtime to `nodejs24.x` in #135. The only runtime where this would regress is Node 18.x, where `File` was not yet global.

**The type import move is a strict improvement.** `@sveltejs/kit/types` is not in the export map of *any* of 1.5.0, 2.x or 3.x. It resolves today only because this package's `tsconfig.json` uses `moduleResolution: "node"`, which ignores export maps and walks the directory. `Builder` and `Server` are both exported from the package root in 1.5.0, 2.x and 3.x, so the root import resolves under every resolution mode. I deliberately left the `@sveltejs/kit: 1.5.0` devDependency alone so this builds unchanged for you.

## Verification

Tested against `@sveltejs/kit@3.0.0-next.23`, `svelte@5.56.4`, `vite@8.2.1`, `@sveltejs/vite-plugin-svelte@7.3.0`, Node 22.19, on a real SvelteKit app (cookie-session auth, `hooks.server.ts` gate, server `load`, one remote function).

A SvelteKit **2.69.1** baseline with the unpatched adapter was established first, so the comparison is like for like.

| Check | Before | After |
|---|---|---|
| `vite build` emits `.svelte-kit/svelte-kit-sst/{client,server,prerendered}` | pass | pass |
| Lambda handler imports | **ERR_PACKAGE_PATH_NOT_EXPORTED** | pass |
| `GET /` unauthenticated, hook redirects | n/a | 302 to `/login` |
| `GET /login`, external redirect to the auth issuer | n/a | 302, correct URL |
| `GET /<page>` server-rendered | n/a | 200, `text/html` |
| Server-rendered rows from a `query` remote function in the first HTML | n/a | 5 |
| `svelte-check` | n/a | 622 files, 0 errors |

The handler was invoked in-process with synthetic API Gateway v2 events, so this exercises the adapter output and the SvelteKit server, and it confirms every `Builder` and `Server` method the adapter uses is unchanged in SvelteKit 3.

## What I did not verify

- **No AWS deployment.** CloudFront, the SST router, S3 asset serving and response streaming were not exercised.
- **CloudFront Lambda@Edge event shape** was not tested; only API Gateway v2.
- **Node 18.x**, where dropping the `File` polyfill would be a real regression. If you support Node 18 for this adapter, this needs a version guard instead of a removal, and I am happy to change it.
- I did not run this repo's own build or test suite.

Happy to open an issue first if you would rather follow the CONTRIBUTING flow, or to adjust the scope.

https://claude.ai/code/session_0152Y7kA75cN4AqFNzBKpEHe
